### PR TITLE
Enroll repository in Roundhouse development

### DIFF
--- a/.roundhouse/profile.yaml
+++ b/.roundhouse/profile.yaml
@@ -1,0 +1,6 @@
+version: 1
+paths:
+  allowed:
+    - "**"
+  protected:
+    - ".github/workflows/**"


### PR DESCRIPTION
Adds the repository-owned path profile required for Roundhouse development enrollment. Source changes are allowed across the repository, while GitHub Actions workflows remain protected; Roundhouse also protects the profile directory itself.