### PR TITLE
Enable fast CI on the development fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    if: github.repository == 'dreamwidth/dreamwidth'
+    if: github.repository == 'dreamwidth/dreamwidth' || github.repository == 'zorkian/dreamwidth'
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary

Allow the existing fast CI job to run on `zorkian/dreamwidth` as well as the upstream `dreamwidth/dreamwidth` repository.

This lets Roundhouse pilot pull requests receive real Dreamwidth test results instead of a skipped check. No test steps or deployment workflows are changed.